### PR TITLE
journal ordering should take dateFormat into account

### DIFF
--- a/src/scripts/JournalingView.ts
+++ b/src/scripts/JournalingView.ts
@@ -29,8 +29,8 @@ async function scanDirectories(
                 const fileNameWithoutExtA = a.name.replace(".md", "");
                 const fileNameWithoutExtB = b.name.replace(".md", "");
 
-                const dateA = moment.utc(fileNameWithoutExtA);
-                const dateB = moment.utc(fileNameWithoutExtB);
+                const dateA = moment.utc(fileNameWithoutExtA, dateFormat);
+                const dateB = moment.utc(fileNameWithoutExtB, dateFormat);
 
                 return filterValue === "new"
                     ? dateB.diff(dateA)


### PR DESCRIPTION
pass dateFormat to moment.utc so it parses date correctly. currently it ignores the dateFormat, leading to incorrect ordering.